### PR TITLE
Implement US11:

### DIFF
--- a/configuration.properties
+++ b/configuration.properties
@@ -5,9 +5,9 @@ url=http://qa.uplifterp.com/web/login
 pos_manager_email=posmanager6@info.com
 pos_manager_password=posmanager
 
-salesmanager15=salesmanager15@info.com
-salesmanager50=salesmanager50@info.com
-salesmanagerPassword=salesmanager
+sales_manager_email=salesmanager15@info.com
+sales_manager_50=salesmanager50@info.com
+sales_manager_password=salesmanager
 
 Inv_Mng_email=inn@info.com
 Inv_Mng_password=inventorymanager

--- a/src/test/java/com/project_name/pages/US11_Sales_Quot_MP_Page.java
+++ b/src/test/java/com/project_name/pages/US11_Sales_Quot_MP_Page.java
@@ -1,0 +1,27 @@
+package com.project_name.pages;
+
+import com.project_name.utilities.Driver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.List;
+
+public class US11_Sales_Quot_MP_Page {
+
+    public US11_Sales_Quot_MP_Page() {
+        PageFactory.initElements(Driver.getDriver(), this);
+    }
+
+
+    @FindBy(xpath = "//a[@class='oe_menu_toggler']/span[normalize-space(text())='Sales']")
+    public WebElement salesButton;
+
+    @FindBy(xpath = "//th[@class='o_list_record_selector']//input[@type='checkbox']")
+    public WebElement quotationNumberCheckbox;
+
+    @FindBy(xpath = "//tbody//input[@type='checkbox']")
+    public List<WebElement> rowCheckboxes;
+
+
+}

--- a/src/test/java/com/project_name/step_definitions/US11_Sales_Quotations_MP_StepDefinitions.java
+++ b/src/test/java/com/project_name/step_definitions/US11_Sales_Quotations_MP_StepDefinitions.java
@@ -1,0 +1,60 @@
+package com.project_name.step_definitions;
+
+import com.project_name.pages.LoginPage;
+import com.project_name.pages.US11_Sales_Quot_MP_Page;
+import com.project_name.utilities.BrowserUtils;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.Assert;
+import org.openqa.selenium.WebElement;
+
+public class US11_Sales_Quotations_MP_StepDefinitions {
+
+    LoginPage loginPage = new LoginPage();
+    US11_Sales_Quot_MP_Page sales_Quot_MP_Page = new US11_Sales_Quot_MP_Page();
+
+    @Given("{string} user is logged in to the system")
+    public void user_is_logged_in_to_the_system(String role) {
+
+
+        switch (role) {
+            case "POS":
+                loginPage.loginAs("POS Manager");
+                break;
+            case "Sales Manager":
+                loginPage.loginAs("Sales Manager");
+        }
+
+    }
+    @Given("user navigates to the Sales page")
+    public void user_navigates_to_the_sales_page() {
+
+        BrowserUtils.waitForClickablility(sales_Quot_MP_Page.salesButton, 10);
+        sales_Quot_MP_Page.salesButton.click();
+        BrowserUtils.sleep(3);
+
+    }
+    @When("user clicks the Quotation Number checkbox")
+    public void user_clicks_the_quotation_number_checkbox() {
+
+        BrowserUtils.waitForVisibility(sales_Quot_MP_Page.quotationNumberCheckbox, 10);
+        sales_Quot_MP_Page.quotationNumberCheckbox.click();
+        BrowserUtils.sleep(3);
+
+
+
+    }
+    @Then("all quotations in the list should be selected")
+    public void all_quotations_in_the_list_should_be_selected() {
+
+        for (WebElement checkbox : sales_Quot_MP_Page.rowCheckboxes) {
+            Assert.assertTrue(checkbox.isSelected());
+        }
+
+
+
+    }
+
+
+}

--- a/src/test/resources/features/US11_Sales_Quotations_MP.feature
+++ b/src/test/resources/features/US11_Sales_Quotations_MP.feature
@@ -1,0 +1,14 @@
+Feature: Manage quotations on the Sales page by different user roles
+
+  @maryna
+  Scenario Outline: User manages quotations
+    Given "<role>" user is logged in to the system
+    And user navigates to the Sales page
+    When user clicks the Quotation Number checkbox
+    Then all quotations in the list should be selected
+    Examples:
+      | role          |
+      | POS           |
+      | Sales Manager |
+
+


### PR DESCRIPTION
- Added SalesPage POM with locators for Sales menu, header checkbox, and row checkboxes
- Created step definitions for login, navigation to Sales, and bulk selection of quotations
- Updated configuration.properties keys for Sales Manager to sales_manager_email and sales_manager_password to match the format expected by the loginAs method (lowercase, underscores), fixing a credentials loading issue.
- Implemented validation that all quotations are selected after clicking header checkbox